### PR TITLE
Free publish_message resource

### DIFF
--- a/examples/smart_outlet/main/smart_outlet_example.c
+++ b/examples/smart_outlet/main/smart_outlet_example.c
@@ -104,6 +104,7 @@ void publish_telemetry_event(iotc_context_handle_t context_handle,
                  iotc_example_qos,
                  /*callback=*/NULL, /*user_data=*/NULL);
     free(publish_topic);
+    free(publish_message);
 }
 
 void iotc_mqttlogic_subscribe_callback(


### PR DESCRIPTION
Both `publish_topic` and `publish_message` char* are allocated, but only `publish_topic` was freed.
This commit also frees `publish_message`.